### PR TITLE
Do not allow bombs to increment when max bombs at 0

### DIFF
--- a/capacityupgrades.asm
+++ b/capacityupgrades.asm
@@ -8,6 +8,8 @@ IncrementBombs:
     LDA !BOMB_UPGRADES ; get bomb upgrades
 	!ADD.l StartingMaxBombs : DEC
 
+    CMP.b #$FF : BEQ + ; if max bombs is 0, it underflows to $FF. Don't add bombs
+
     CMP !BOMB_CURRENT
 	
 	!BLT +

--- a/inventory.asm
+++ b/inventory.asm
@@ -756,6 +756,10 @@ RTS
 ; Link_ReceiveItem_HUDRefresh:
 ;--------------------------------------------------------------------------------
 Link_ReceiveItem_HUDRefresh:
+    LDA $7EF370 ; get bomb upgrades
+	!ADD.l StartingMaxBombs
+    CMP.b #0 : BEQ + ; do not add bombs if you can't carry any
+
 	LDA $7EF343 : BNE + ; skip if we have bombs
 	LDA $7EF375 : BEQ + ; skip if we are filling no bombs
 		DEC : STA $7EF375 ; decrease bomb fill count
@@ -773,6 +777,11 @@ RTL
 HandleBombAbsorbtion:
 	STA $7EF375 ; thing we wrote over
 	LDA $0303 : BNE + ; skip if we already have some item selected
+
+    LDA $7EF370 ; get bomb upgrades
+	!ADD.l StartingMaxBombs
+    CMP.b #0 : BEQ + ; do not switch to bombs if you can't carry any
+
 		LDA.b #$04 : STA $0202 ; set selected item to bombs
 		LDA.b #$01 : STA $0303 ; set selected item to bombs
 		JSL.l HUD_RebuildLong


### PR DESCRIPTION
I am working on an AP feature to allow you to start your max bombs at 0. This requires some changes to the base rom as otherwise you can acquire 99 bombs when the max is set to 0.