### PR TITLE
Add silver Power Star item

### DIFF
--- a/newitems.asm
+++ b/newitems.asm
@@ -29,10 +29,10 @@
 ; #$63 - RNG Pool Item (Multi)
 ; #$64 - Progressive Bow
 ; #$65 - Progressive Bow
-; #$69 - Alt Power Star
-; #$6A - Goal Item (Triforce)
-; #$6B - Power Star
-; #$6C - Goal Item (Triforce Piece)
+; #$69 - Gold Power Star
+; #$6A - Triforce
+; #$6B - Silver Power Star
+; #$6C - Triforce Piece
 ; #$6D - Server Request F0 (Hearts / Powder / Mushroom / Bonkable)
 ; #$6E - Server Request F1 (NPC)
 ; #$6F - Server Request F2 (Tablets / Pedestal)
@@ -327,12 +327,14 @@ AddReceivedItemExpandedGetItem:
 		BRL .done
 	+ CMP.b #$65 : BNE + ; Progressive Bow
 		BRL .done
-	+ CMP.b #$6A : BNE + ; Goal Collectable (Single/Triforce)
+	+ CMP.b #$69 : BNE + ; Gold Power Star
+		BRA .multi_collect
+	+ CMP.b #$6A : BNE + ; Triforce
 		JSL.l ActivateGoal
 		BRL .done
-	+ CMP.b #$6B : BNE + ; Goal Collectable (Multi/Power Star)
+	+ CMP.b #$6B : BNE + ; Silver Power Star
 		BRA .multi_collect
-	+ CMP.b #$6C : BNE + ; Goal Collectable (Multi/Power Star) Alternate Graphic
+	+ CMP.b #$6C : BNE + ; Triforce Piece
 		.multi_collect
 		REP #$20
 		LDA GoalItemRequirement : BEQ ++
@@ -623,7 +625,7 @@ AddReceivedItemExpanded:
 	db -4, -4 ; RNG Single & Multi
 	db -4, -4 ; Progressive Bow x2
 	db -4, -4, -4 ; Unused
-	db -4, -4, -4, -4 ; Alt Power Star, Triforce, Power Star, Triforce Piece
+	db -4, -4, -4, -4 ; Gold Power Star, Triforce, Silver Power Star, Triforce Piece
 	db -4, -4, -4 ; Unused
 	db -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4 ; Free Map
 	db -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4 ; Free Compass
@@ -663,7 +665,7 @@ AddReceivedItemExpanded:
 	db  0, 0 ; RNG Single & Multi
 	db  0, 0 ; Progressive Bow x2
 	db  0, 0, 0 ; Unused
-	db  0, 0, 0, 0 ; Alt Power Star, Triforce, Power Star, Triforce Piece
+	db  0, 0, 0, 0 ; Gold Power Star, Triforce, Silver Power Star, Triforce Piece
 	db  0, 0, 0 ; Unused
 	db  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ; Free Map
 	db  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ; Free Compass
@@ -705,7 +707,7 @@ AddReceivedItemExpanded:
 	db $FF, $FF ; RNG Single & Multi
 	db $FF, $FF ; Progressive Bow x2
 	db $FF, $FF, $FF ; Unused
-	db $4A, $49, $4A, $49; Alt Power Star, Triforce, Power Star, Triforce Piece
+	db $4A, $49, $4A, $49; Gold Power Star, Triforce, Silver Power Star, Triforce Piece
 	db $FF, $FF, $FF ; Unused
 	db $21, $21, $21, $21, $21, $21, $21, $21, $21, $21, $21, $21, $21, $21, $21, $21 ; Free Map
 	db $16, $16, $16, $16, $16, $16, $16, $16, $16, $16, $16, $16, $16, $16, $16, $16 ; Free Compass
@@ -751,7 +753,7 @@ AddReceivedItemExpanded:
 	db $02, $02 ; RNG Single & Multi
 	db $02, $02 ; Progressive Bow x2
 	db $02, $02, $02 ; Unused
-	db $02, $02, $02, $02 ; Alt Power Star, Triforce, Power Star, Triforce Piece
+	db $02, $02, $02, $02 ; Gold Power Star, Triforce, Silver Power Star, Triforce Piece
 	db $02, $02, $02 ; Unused
 	db $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02 ; Free Map
 	db $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02 ; Free Compass
@@ -793,7 +795,7 @@ AddReceivedItemExpanded:
 	db  $FF, $FF ; RNG Single & Multi
 	db  0, 0 ; Progressive Bow
 	db  0, 0, 0 ; Unused
-	db  4, 4, 4, 4 ; Alt Power Star, Triforce, Power Star, Triforce Piece
+	db  4, 4, 1, 4 ; Gold Power Star, Triforce, Silver Power Star, Triforce Piece
 	db  0, 0, 0 ; Unused
 	db  4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 ; Free Map
 	db  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ; Free Compass
@@ -835,7 +837,7 @@ AddReceivedItemExpanded:
 	dw $F36A, $F36A ; RNG Single & Multi
 	dw $F340, $F340 ; Progressive Bow x2
 	dw $F36A, $F36A, $F36A ; Unused
-	dw $F36A, $F36A, $F36A, $F36A ; Alt Power Star, Triforce, Power Star, Triforce Piece
+	dw $F36A, $F36A, $F36A, $F36A ; Gold Power Star, Triforce, Silver Power Star, Triforce Piece
 	dw $F36A, $F36A, $F36A ; Unused
 	dw $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A ; Free Map
 	dw $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A ; Free Compass
@@ -879,7 +881,7 @@ AddReceivedItemExpanded:
 	db $FF, $FF ; RNG Single & Multi
 	db $FF, $FF ; Progressive Bow
 	db $FF, $FF, $FF ; Unused
-	db $FF, $FF, $FF, $FF ; Alt Power Star, Triforce, Power Star, Triforce Piece
+	db $FF, $FF, $FF, $FF ; Gold Power Star, Triforce, Silver Power Star, Triforce Piece
 	db $FF, $FF, $FF ; Unused
 	db $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF ; Free Map
 	db $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF ; Free Compass
@@ -965,7 +967,7 @@ Link_ReceiveItemAlternatesExpanded:
 	db -1, -1 ; RNG Single & Multi
 	db -1, -1 ; Progressive Bow
 	db -1, -1, -1 ; Unused
-	db -1, -1, -1, -1 ; Alt Power Star, Triforce, Power Star, Triforce Piece
+	db -1, -1, -1, -1 ; Gold Power Star, Triforce, Silver Power Star, Triforce Piece
 	db -1, -1, -1 ; Unused
 	db -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 ; Free Map
 	db -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 ; Free Compass

--- a/newitems.asm
+++ b/newitems.asm
@@ -29,9 +29,10 @@
 ; #$63 - RNG Pool Item (Multi)
 ; #$64 - Progressive Bow
 ; #$65 - Progressive Bow
-; #$6A - Goal Item (Single/Triforce)
-; #$6B - Goal Item (Multi/Power Star)
-; #$6C - Goal Item (Multi/Triforce Piece)
+; #$69 - Alt Power Star
+; #$6A - Goal Item (Triforce)
+; #$6B - Power Star
+; #$6C - Goal Item (Triforce Piece)
 ; #$6D - Server Request F0 (Hearts / Powder / Mushroom / Bonkable)
 ; #$6E - Server Request F1 (NPC)
 ; #$6F - Server Request F2 (Tablets / Pedestal)
@@ -621,8 +622,8 @@ AddReceivedItemExpanded:
 	db -4, -4, -4, -4 ; Progressive Sword, Shield, Armor & Gloves
 	db -4, -4 ; RNG Single & Multi
 	db -4, -4 ; Progressive Bow x2
-	db -4, -4, -4, -4 ; Unused
-	db -4, -4, -4 ; Goal Item Single, Multi & Alt Multi
+	db -4, -4, -4 ; Unused
+	db -4, -4, -4, -4 ; Alt Power Star, Triforce, Power Star, Triforce Piece
 	db -4, -4, -4 ; Unused
 	db -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4 ; Free Map
 	db -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4 ; Free Compass
@@ -661,8 +662,8 @@ AddReceivedItemExpanded:
 	db  0, 0, 0, 0 ; Progressive Sword, Shield, Armor & Gloves
 	db  0, 0 ; RNG Single & Multi
 	db  0, 0 ; Progressive Bow x2
-	db  0, 0, 0, 0 ; Unused
-	db  0, 0, 0 ; Goal Item Single, Multi & Alt Multi
+	db  0, 0, 0 ; Unused
+	db  0, 0, 0, 0 ; Alt Power Star, Triforce, Power Star, Triforce Piece
 	db  0, 0, 0 ; Unused
 	db  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ; Free Map
 	db  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ; Free Compass
@@ -703,8 +704,8 @@ AddReceivedItemExpanded:
 	db $FF, $FF, $04, $0D ; Progressive Sword, Shield, Armor & Gloves
 	db $FF, $FF ; RNG Single & Multi
 	db $FF, $FF ; Progressive Bow x2
-	db $FF, $FF, $FF, $FF ; Unused
-	db $49, $4A, $49 ; Goal Item Single, Multi & Alt Multi
+	db $FF, $FF, $FF ; Unused
+	db $4A, $49, $4A, $49; Alt Power Star, Triforce, Power Star, Triforce Piece
 	db $FF, $FF, $FF ; Unused
 	db $21, $21, $21, $21, $21, $21, $21, $21, $21, $21, $21, $21, $21, $21, $21, $21 ; Free Map
 	db $16, $16, $16, $16, $16, $16, $16, $16, $16, $16, $16, $16, $16, $16, $16, $16 ; Free Compass
@@ -749,8 +750,8 @@ AddReceivedItemExpanded:
 	db $02, $02, $02, $02 ; Progressive Sword, Shield, Armor & Gloves
 	db $02, $02 ; RNG Single & Multi
 	db $02, $02 ; Progressive Bow x2
-	db $02, $02, $02, $02 ; Unused
-	db $02, $02, $02 ; Goal Item Single, Multi & Alt Multi
+	db $02, $02, $02 ; Unused
+	db $02, $02, $02, $02 ; Alt Power Star, Triforce, Power Star, Triforce Piece
 	db $02, $02, $02 ; Unused
 	db $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02 ; Free Map
 	db $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02, $02 ; Free Compass
@@ -791,8 +792,8 @@ AddReceivedItemExpanded:
 	db  $FF, $FF, $FF, $FF ; Progressive Sword, Shield, Armor & Gloves
 	db  $FF, $FF ; RNG Single & Multi
 	db  0, 0 ; Progressive Bow
-	db  0, 0, 0, 0 ; Unused
-	db  4, 4, 4 ; Goal Item Single, Multi & Alt Multi
+	db  0, 0, 0 ; Unused
+	db  4, 4, 4, 4 ; Alt Power Star, Triforce, Power Star, Triforce Piece
 	db  0, 0, 0 ; Unused
 	db  4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 ; Free Map
 	db  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ; Free Compass
@@ -833,8 +834,8 @@ AddReceivedItemExpanded:
 	dw $F359, $F35A, $F35B, $F354 ; Progressive Sword, Shield, Armor & Gloves
 	dw $F36A, $F36A ; RNG Single & Multi
 	dw $F340, $F340 ; Progressive Bow x2
-	dw $F36A, $F36A, $F36A, $F36A ; Unused
-	dw $F36A, $F36A, $F36A ; Goal Item Single, Multi & Alt Multi
+	dw $F36A, $F36A, $F36A ; Unused
+	dw $F36A, $F36A, $F36A, $F36A ; Alt Power Star, Triforce, Power Star, Triforce Piece
 	dw $F36A, $F36A, $F36A ; Unused
 	dw $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A ; Free Map
 	dw $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A, $F36A ; Free Compass
@@ -877,8 +878,8 @@ AddReceivedItemExpanded:
 	db $FF, $FF, $FF, $FF ; Progressive Sword, Shield, Armor & Gloves
 	db $FF, $FF ; RNG Single & Multi
 	db $FF, $FF ; Progressive Bow
-	db $FF, $FF, $FF, $FF ; Unused
-	db $FF, $FF, $FF ; Goal Item Single, Multi & Alt Multi
+	db $FF, $FF, $FF ; Unused
+	db $FF, $FF, $FF, $FF ; Alt Power Star, Triforce, Power Star, Triforce Piece
 	db $FF, $FF, $FF ; Unused
 	db $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF ; Free Map
 	db $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF ; Free Compass
@@ -963,9 +964,9 @@ Link_ReceiveItemAlternatesExpanded:
 	db -1, -1, -1, -1 ; Progressive Sword, Shield, Armor & Gloves
 	db -1, -1 ; RNG Single & Multi
 	db -1, -1 ; Progressive Bow
-	db -1, -1, -1, -1 ; Unused
-	db -1, -1 ; Goal Item Single, Multi & Alt Multi
-	db -1, -1, -1, -1 ; Unused
+	db -1, -1, -1 ; Unused
+	db -1, -1, -1, -1 ; Alt Power Star, Triforce, Power Star, Triforce Piece
+	db -1, -1, -1 ; Unused
 	db -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 ; Free Map
 	db -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 ; Free Compass
 	db -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 ; Free Big Key

--- a/newitems.asm
+++ b/newitems.asm
@@ -327,13 +327,11 @@ AddReceivedItemExpandedGetItem:
 		BRL .done
 	+ CMP.b #$65 : BNE + ; Progressive Bow
 		BRL .done
-	+ CMP.b #$69 : BNE + ; Gold Power Star
-		BRA .multi_collect
+	+ CMP.b #$69 : BEQ .multi_collect ; Gold Power Star
 	+ CMP.b #$6A : BNE + ; Triforce
 		JSL.l ActivateGoal
 		BRL .done
-	+ CMP.b #$6B : BNE + ; Silver Power Star
-		BRA .multi_collect
+	+ CMP.b #$6B : BEQ .multi_collect ; Silver Power Star
 	+ CMP.b #$6C : BNE + ; Triforce Piece
 		.multi_collect
 		REP #$20

--- a/tables.asm
+++ b/tables.asm
@@ -1326,8 +1326,10 @@ db $04
 ;64:Progressive Bow
 ;65:Progressive Bow
 
-;6A:Goal Item (Single/Triforce)
-;6B:Goal Item (Multi/Power Star)
+;69:Alt Power Star
+;6A:Goal Item (Triforce)
+;6B:Power Star
+;6C:Goal Item (Triforce Piece)
 
 ;6D:Server Request Item
 ;6E:Server Request Item (Dungeon Drop)

--- a/tables.asm
+++ b/tables.asm
@@ -1326,9 +1326,9 @@ db $04
 ;64:Progressive Bow
 ;65:Progressive Bow
 
-;69:Alt Power Star
+;69:Gold Power Star
 ;6A:Goal Item (Triforce)
-;6B:Power Star
+;6B:Silver Power Star
 ;6C:Goal Item (Triforce Piece)
 
 ;6D:Server Request Item

--- a/utilities.asm
+++ b/utilities.asm
@@ -152,8 +152,8 @@ RTL
 	db $FD, $0D ; Progressive Armor & Gloves
 	db $FA, $FB ; RNG Single & Multi
 	db $F8, $F8 ; Progressive Bow x2
-	db $FF, $FF, $FF, $FF ; Unused
-	db $49, $4A, $49 ; Goal Item Single, Multi & Alt Multi
+	db $FF, $FF, $FF ; Unused
+	db $4A, $49, $4A, $49 ; Alt Power Star, Triforce, Power Star, Triforce Piece
 	db $39, $39, $39 ; Server Request F0, F1, F2
 
 	;7x
@@ -296,8 +296,8 @@ RTL
 	db $FD, $FE, $FF, $FC ; Progressive Sword, Shield, Armor & Gloves
 	db $FA, $FB ; RNG Single & Multi
 	db $F8, $F8 ; Progressive Bow
-	db $00, $00, $00, $00 ; Unused
-	db $08, $08, $08 ; Goal Item Single, Multi & Alt Multi
+	db $00, $00, $00 ; Unused
+	db $08, $08, $02, $08 ; Alt Power Star, Triforce, Power Star, Triforce Piece
 	db $04, $04, $04 ; Server Request F0, F1, F2
 	
 	db $08, $08, $08, $08, $08, $08, $08, $08, $08, $08, $08, $08, $08, $08, $08, $08 ; Free Map

--- a/utilities.asm
+++ b/utilities.asm
@@ -153,7 +153,7 @@ RTL
 	db $FA, $FB ; RNG Single & Multi
 	db $F8, $F8 ; Progressive Bow x2
 	db $FF, $FF, $FF ; Unused
-	db $4A, $49, $4A, $49 ; Alt Power Star, Triforce, Power Star, Triforce Piece
+	db $4A, $49, $4A, $49 ; Gold Power Star, Triforce, Silver Power Star, Triforce Piece
 	db $39, $39, $39 ; Server Request F0, F1, F2
 
 	;7x
@@ -297,7 +297,7 @@ RTL
 	db $FA, $FB ; RNG Single & Multi
 	db $F8, $F8 ; Progressive Bow
 	db $00, $00, $00 ; Unused
-	db $08, $08, $02, $08 ; Alt Power Star, Triforce, Power Star, Triforce Piece
+	db $08, $08, $02, $08 ; Gold Power Star, Triforce, Silver Power Star, Triforce Piece
 	db $04, $04, $04 ; Server Request F0, F1, F2
 	
 	db $08, $08, $08, $08, $08, $08, $08, $08, $08, $08, $08, $08, $08, $08, $08, $08 ; Free Map


### PR DESCRIPTION
This change adds item ID 0x69 (currently unused) which duplicates the data of the existing 0x6B "Goal Item (Multi/Power Star)" and changes the palette of the existing power star item to 0x02 (silver).  This is intended to allow differentiating progression items (gold stars) from non-progression items (silver stars) for other worlds.